### PR TITLE
Add JSON Viewer Tool to the JSON section

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ List of some useful free online tools and sites
 - [**JSON Minifier** - (*Minify your JSON data online to reduce file size*)](https://99tools.net/json-minifier/)
 - [**JSON to C#** - (*Convert JSON to C# Classes Online*)](https://json2csharp.com/)
 - [**JSON Validator** - (*Validates a JSON file*)](https://www.appdevtools.com/json-validator)
+- [**JSON Viewer Tool** - (*View, format, validate, minify, compare and convert JSON to CSV/YAML/XML in the browser — 100% client-side, no uploads*)](https://jsonviewertool.com/)
 - [**JWT Decoder** - (*Decode a JSON Web Token to view the claims inside*)](https://www.appdevtools.com/jwt-decoder)
 - [**JSON Web Token Decoder** - (*Decode a JSON Web Token with different algorithms*)](https://jwt.io/)
 


### PR DESCRIPTION
Adds [JSON Viewer Tool](https://jsonviewertool.com/) to the **JSON** section (alphabetically, after JSON Validator).

A free, 100% client-side suite of JSON utilities — viewer, formatter, validator, minifier, compare/diff, and converters (JSON↔CSV, YAML, XML). No signup and nothing is uploaded; everything runs in the browser. Fits the list's free/online/privacy-friendly theme.

Thanks for maintaining this!