### PR TITLE
Add Text Machine to Strings and Texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ List of some useful free online tools and sites
 - [**Characters and Symbols** - (*Standard ASCII set, HTML Entity names, ISO 10646, ISO 8879, ISO 8859-1 Latin alphabet No. 1*)](https://ascii.cl/htmlcodes.htm)
 - [**Random text generator** - (*Create dummy text for all your layout needs*)](https://slothman.dev/text-generator/)
 - [**String Utilities** - (*Counts the characters, words, lines, reverts the text, and converts text to lowercase or UPPERCASE*)](https://www.appdevtools.com/string-utilities)
+- [**Text Machine** - (*Free, privacy-first suite of 140+ in-browser text tools: classical ciphers, Base64/URL/HTML encoders, CSV/JSON converters, case/format changers, counters. No signup, nothing uploaded*)](https://textmachine.org/)
 - [**Text to Image** - (*Convert Text into Image in seconds*)](https://textintoimages.com/)
 - [**Word Counter** - (*Count the number of words, characters, sentences, and paragraphs in your text in one click*)](https://tools.word-counter.com/)
 


### PR DESCRIPTION
Adds [Text Machine](https://textmachine.org/) to **Strings and Texts**.

A free, privacy-first suite of 140+ in-browser text tools (classical ciphers, Base64/URL/HTML encoders, CSV/JSON converters, case/format changers, counters). Nothing is uploaded, no signup. Free; placed alphabetically per the contribution note.