### PR TITLE
Add UtilGears to Calculators & Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ List of some useful free online tools and sites
 - [**ToolKnit** - (*76 free browser-based tools for PDF, image, video, audio, text, calculators, time, charting and more. No uploads, no sign-up, 100% client-side, no watermarks*)](https://toolknit.com)
 - [**Torque Converter** - (*Convert between Torque units*)](https://convertlive.com/c/convert/torque)
 - [**Unit Converter** - (*Converts a value from a unit to another*)](https://www.appdevtools.com/unit-converter)
+- [**UtilGears** - (*100+ free, privacy-first calculators, converters and text/developer tools — no signup, runs in your browser*)](https://utilgears.com)
 - [**Volume Converter** - (*Convert between Volume units*)](https://convertlive.com/c/convert/volume)
 - [**Weight Converter** - (*Convert between Weight units*)](https://convertlive.com/c/convert/weight)
 


### PR DESCRIPTION
Adds UtilGears (utilgears.com) — a free, privacy-first set of 100+ online calculators, converters and text/developer tools that run client-side (no signup, no uploads). Placed alphabetically in Calculators & Converters.