### PR TITLE
Add JotTools to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ List of some useful free online tools and sites
 
 ## <a name="productivity"></a>**Productivity**
 - <img src="assets/images/windows.svg" width="20" height="20"> Windows [**Microsoft PowerToys** - (*Set of utilities to tune and streamline their Windows 10 and 11 experience for greater productivity*)](https://apps.microsoft.com/store/detail/microsoft-powertoys/XP89DCGQ3K6VLD)
+- [**JotTools** - (*130+ free browser-based tools: PDF, image, text, color, calculators and developer utilities, all client-side with no signup*)](https://jottools.com)
 - [**Notion** - (*All-in-one workspace*)](https://www.notion.so/)
 - [**Pomodoro Tracker** - (*Online Pomodoro Tool*)](https://pomodoro-tracker.com/)
 


### PR DESCRIPTION
Adds JotTools (https://jottools.com) to the Productivity section, a suite of 130+ free browser-based tools (PDF, image, text, color, calculators, developer utilities) that run client-side with no signup and nothing uploaded. Placed alphabetically, following the existing entry format.