### PR TITLE
Add RevealTheme to SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ List of some useful free online tools and sites
 
 ## <a name="SEO"></a>**SEO**
 - [**PageRank Calculator** - (*CSV file: Type,Destination,Rel,Source - Hyperlink,Html_Url,link,Site_Url*)](https://pagerank.streamlit.app/)
+- [**RevealTheme** - (*Detect what WordPress theme, plugins, and page builder a site uses*)](https://revealtheme.com/)
 
 ## <a name="sharing"></a>**Sharing**
 - [**Imgbb** - (*Upload & Share your images*)](https://imgbb.com/)


### PR DESCRIPTION
Adds [RevealTheme](https://revealtheme.com/), a free tool to detect what WordPress theme, plugins, and page builder a given site uses — fits alongside PageRank Calculator as another site-analysis/SEO research tool.