### PR TITLE
Add Nutilz Square Footage Calculator to Calculators & Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ List of some useful free online tools and sites
 - [**Length Converter** - (*Convert between Length units*)](https://convertlive.com/c/convert/length)
 - [**Mac Cable Bandwidth Calculator** - (*Check whether a USB-C, HDMI, DisplayPort, or Thunderbolt cable can drive 4K120, 5K60, or 6K on a Mac*)](https://retinadesk.com/tools/cable-bandwidth-calculator/)
 - [**Mac PPI Calculator & Retina Checker** - (*Calculate a monitor's pixel density and whether it renders Retina-sharp on macOS, with a HiDPI scaling preview*)](https://retinadesk.com/tools/ppi-calculator/)
+- [**Nutilz Square Footage Calculator** - (*Free browser-based calculator for square footage, room area, and material coverage estimates — no signup, works for rectangular, circular, and irregular spaces*)](https://nutilz.com/square-footage-calculator)
 - [**Percentage Calculator** - (*Calculate Percentages*)](https://www.thecalculator.website/percentage-calculator)
 - [**Power Converter** - (*Convert between Power units*)](https://convertlive.com/c/convert/power)
 - [**Pressure Converter** - (*Convert between Pressure units*)](https://convertlive.com/c/convert/pressure)


### PR DESCRIPTION
Adds Nutilz Square Footage Calculator (https://nutilz.com/square-footage-calculator), a free browser-based calculator for square footage / room area / material coverage estimates. No signup, works client-side. Placed alphabetically in the Calculators & Converters section between Mac PPI Calculator and Percentage Calculator.