### PR TITLE
Add Nutilz Aspect Ratio Calculator to Calculators & Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ List of some useful free online tools and sites
 - [**Length Converter** - (*Convert between Length units*)](https://convertlive.com/c/convert/length)
 - [**Mac Cable Bandwidth Calculator** - (*Check whether a USB-C, HDMI, DisplayPort, or Thunderbolt cable can drive 4K120, 5K60, or 6K on a Mac*)](https://retinadesk.com/tools/cable-bandwidth-calculator/)
 - [**Mac PPI Calculator & Retina Checker** - (*Calculate a monitor's pixel density and whether it renders Retina-sharp on macOS, with a HiDPI scaling preview*)](https://retinadesk.com/tools/ppi-calculator/)
+- [**Nutilz Aspect Ratio Calculator** - (*Find or scale aspect ratios for video, photo, and design work — enter dimensions to get the simplified ratio, or scale to a new size preserving the same ratio. Free, no signup*)](https://nutilz.com/aspect-ratio)
 - [**Percentage Calculator** - (*Calculate Percentages*)](https://www.thecalculator.website/percentage-calculator)
 - [**Power Converter** - (*Convert between Power units*)](https://convertlive.com/c/convert/power)
 - [**Pressure Converter** - (*Convert between Pressure units*)](https://convertlive.com/c/convert/pressure)


### PR DESCRIPTION
Adds Nutilz Aspect Ratio Calculator (https://nutilz.com/aspect-ratio) alphabetically to the Calculators & Converters section, between Mac PPI Calculator and Percentage Calculator.

Free, browser-based tool that finds the simplified aspect ratio from a width/height pair, or scales a size to a new dimension while preserving the ratio (common presets like 16:9, 4:3, 1:1, 9:16 included). No signup required.