### PR TITLE
Add Video Size Reducer to Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ List of some useful free online tools and sites
 - [**TikTok Video Downloader** - (*Download TikTok videos in MP4 format*)](https://www.convertidor.mx/herramientas/descargar-videos-tiktok.html)
 - [**Trim Video** - (*Trim or cut video of any format*)](https://online-video-cutter.com/es/)
 - [**UnScreen** - (*Remove Video Background [only for videos of 5 seconds]*)](https://unscreen.pro/)
+- [**Video Size Reducer** - (*Compress MP4 videos to a target file size, entirely in your browser*)](https://videosizereducer.org/)
 - [**VidMix** - (*Edit videos with your web browser*)](https://vidmix.app/)
 
 ## <a name="weather"></a>**Weather**


### PR DESCRIPTION
Adds **Video Size Reducer** (https://videosizereducer.org/) to the *Videos* section, between UnScreen and VidMix to keep the list alphabetical.

It compresses MP4 files down to a target size — 10/25/50 MB or a custom limit — which is the usual need when a file is just over an upload cap on Discord, email, or a forum. There is also a resolution-capped quality preset.

It fits this list's scope the same way VidMix and Clideo do: no install, no account, free. Encoding runs through the browser's WebCodecs API, so the selected file is processed locally and never uploaded to a server.
