### PR TITLE
Add Toolerax to Documents and Images and Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ List of some useful free online tools and sites
 - [**Scribd Downloader** - (*Download the Scribd documents in one click*)](https://scribd.downloader.tips/)
 - [**SheetRender** - (*Split a mail merge PDF into separate, named files in your browser with no upload or signup*)](https://sheetrender.com/tools/split-mail-merge-pdf)
 - [**Small PDF** - (*Reduce the size of your PDF online*)](https://smallpdf.com/compress-pdf)
+- [**Toolerax** - (*Merge, split, compress, rotate and convert PDFs — most tools run in the browser with no upload, no signup and no watermark*)](https://toolerax.com/category/pdf-tools)
 - [**Word to PDF** - (*Convert Word documents to PDF*)](https://www.convertidor.mx/herramientas/convertir-docx-a-pdf.html)
 
 ## <a name="email"></a>**Email**
@@ -450,6 +451,7 @@ List of some useful free online tools and sites
 - [**SVG to PNG** - (*SVG to PNG converter*)](https://svgtopng.com/)
 - [**The Spriters Resource** - (*Collection, archival, and appreciation of materials from video games*)](https://www.spriters-resource.com/)
 - [**ToolBench** - (*Free browser-based image converter, compressor, resizer, cropper and watermark tool — no upload, no sign-up*)](https://mytoolsbench.com)
+- [**Toolerax** - (*Compress, resize, crop and convert images, and remove backgrounds with an AI model that runs locally in the browser — no upload, no signup*)](https://toolerax.com/category/image-tools)
 - [**Unsplash** - (*Souce images from Internet*)](https://unsplash.com/)
 - [**WEBp to PNG** - (*Convert WEBp to PNG*)](https://www.convertidor.mx/herramientas/convertir-webp-a-png.html)
 

--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ Thanks to:
 - [Losang](https://github.com/nineinch99)
 - [mainliufeng](https://github.com/mainliufeng)
 - [Manikhan345](https://github.com/Manikhan345)
+- [Md Shohanur Rahman](https://github.com/sarkarsrshohan)
 - [Mhmd-Husseini](https://github.com/Mhmd-Husseini)
 - [Mohammed Almuhanna](https://github.com/Goo6i)
 - [mohamed nasreldeen salem](https://github.com/mohnsrmm)


### PR DESCRIPTION
Adds Toolerax to **Documents** and **Images and Graphics**, both placed alphabetically and following the existing entry format.

Disclosure: I built and maintain this site, so please treat this as a self-submission — happy to drop either entry if you would rather not have them.

It is a free collection of 169 online tools. Why I think it sits well next to the existing entries in those two sections: 102 of the tools run entirely in the browser via WebAssembly, so the file is never uploaded — that is verifiable in the Network tab while merging a PDF. The rest (HEIC, PSD, EPS, Office conversions and OCR) need real document engines, so those are processed server-side and deleted immediately, and each of those pages says so on the page.

No account, no watermark, no daily limit. Both links were checked and return 200.