### PR TITLE
Add Nutilz Salary Calculator to Calculators & Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ List of some useful free online tools and sites
 - [**Nutilz - Fraction Calculator** - (*Add, subtract, multiply and divide fractions with step-by-step solutions. Supports mixed numbers, improper fractions, and simplification. Free, instant*)](https://nutilz.com/fraction-calculator)
 - [**Nutilz - Ideal Weight Calculator** - (*Calculate ideal body weight using four established clinical formulas — Devine, Robinson, Miller and Hamwi. Metric and imperial units, plus WHO BMI-based healthy range. Free, no signup*)](https://nutilz.com/ideal-weight-calculator)
 - [**Nutilz - Mortgage Calculator** - (*Calculate monthly mortgage payments including principal, interest, PMI, property taxes, and homeowners insurance — enter home price and down payment for an instant estimate. Free, no signup*)](https://nutilz.com/mortgage-calculator)
+- [**Nutilz - Salary Calculator** - (*Convert hourly wage to annual salary or annual salary to hourly rate — see weekly, bi-weekly, monthly and quarterly pay breakdowns plus an estimated take-home pay after tax. Free, no signup*)](https://nutilz.com/salary-calculator)
 - [**Nutilz - Square Footage Calculator** - (*Free browser-based calculator for square footage, room area, and material coverage estimates — no signup, works for rectangular, circular, and irregular spaces*)](https://nutilz.com/square-footage-calculator)
 - [**Percentage Calculator** - (*Calculate Percentages*)](https://www.thecalculator.website/percentage-calculator)
 - [**Power Converter** - (*Convert between Power units*)](https://convertlive.com/c/convert/power)


### PR DESCRIPTION
Adds Nutilz Salary Calculator (https://nutilz.com/salary-calculator) — converts hourly wage to annual salary and back, with weekly/bi-weekly/monthly/quarterly breakdowns and an estimated take-home pay after tax. Free, no signup required.